### PR TITLE
add BASE_IMAGE env variable so the kfp uses the correct base image

### DIFF
--- a/tenants/ai-example/dsp-example-pipeline/base/execute-kfp-task.yaml
+++ b/tenants/ai-example/dsp-example-pipeline/base/execute-kfp-task.yaml
@@ -24,5 +24,7 @@ spec:
       env:
         - name: KUBEFLOW_ENDPOINT
           value: $(inputs.params.KUBEFLOW_ENDPOINT)
+        - name: BASE_IMAGE
+          value: $(inputs.params.IMAGE):$(inputs.params.TAG)
       script: |
         python $(inputs.params.SCRIPT)


### PR DESCRIPTION
Adding a BASE_IMAGE env var so the image is used by KFP instead of the default python image.

There is no urgency to merge this change so happy to hold off until after the bootcamp is complete.