### PR TITLE
remove patches for mirrored catalog source

### DIFF
--- a/components/operators/authorino-operator/operator/overlays/managed-services/patch-channel.yaml
+++ b/components/operators/authorino-operator/operator/overlays/managed-services/patch-channel.yaml
@@ -1,6 +1,3 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: 'tech-preview-v1'

--- a/components/operators/openshift-ai/operator/overlays/fast/patch-channel.yaml
+++ b/components/operators/openshift-ai/operator/overlays/fast/patch-channel.yaml
@@ -1,6 +1,3 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: fast

--- a/components/operators/openshift-gitops/operator/overlays/latest/patch-subscription.yaml
+++ b/components/operators/openshift-gitops/operator/overlays/latest/patch-subscription.yaml
@@ -1,7 +1,4 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: latest
 - op: replace

--- a/components/operators/openshift-pipelines/operator/overlays/latest/patch-channel.yaml
+++ b/components/operators/openshift-pipelines/operator/overlays/latest/patch-channel.yaml
@@ -1,6 +1,3 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: latest

--- a/components/operators/openshift-serverless/operator/overlays/stable/patch-channel.yaml
+++ b/components/operators/openshift-serverless/operator/overlays/stable/patch-channel.yaml
@@ -1,6 +1,3 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: stable

--- a/components/operators/openshift-servicemesh/operator/overlays/stable/patch-channel.yaml
+++ b/components/operators/openshift-servicemesh/operator/overlays/stable/patch-channel.yaml
@@ -1,6 +1,3 @@
 - op: replace
-  path: /spec/source
-  value: cs-redhat-operator-index
-- op: replace
   path: /spec/channel
   value: 'stable'


### PR DESCRIPTION
I missed that the disconnected install branch still had patches on the operator catalog sources.

This PR undoes those catalog sources patches.