### PR TITLE
Enhancement for Git Repository Locations option-2

### DIFF
--- a/clusters/overlays/rhoai-eus-2.8-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.8-aws-gpu/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
   - ../../base
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.8-aws-gpu
 
-patches:
-  # set the repo and branch for applications
-  - path: patch-application-repo-revision.yaml
-    target:
-      group: argoproj.io
-      kind: Application
+#Uncomment below patching for repo setup for each overlay
+#patches:
+# set the repo and branch for applications
+#- path: patch-application-repo-revision.yaml
+#  target:
+#    group: argoproj.io
+#    kind: Application
   # Uncomment patches to disable automatic sync
   # - path: patch-applicationset-manual-sync.yaml
   #   target:

--- a/clusters/overlays/rhoai-eus-2.8/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.8/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
   - ../../base
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.8
 
-patches:
-  # set the repo and branch for applications
-  - path: patch-application-repo-revision.yaml
-    target:
-      group: argoproj.io
-      kind: Application
+#Uncomment below patching for repo setup for each overlay
+#patches:
+# set the repo and branch for applications
+#- path: patch-application-repo-revision.yaml
+#  target:
+#    group: argoproj.io
+#    kind: Application
   # Uncomment patches to disable automatic sync
   # - path: patch-applicationset-manual-sync.yaml
   #   target:

--- a/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
   - ../../base
   - ../../../components/argocd/apps/overlays/rhoai-fast-aws-gpu
 
-patches:
-  # set the repo and branch for applications
-  - path: patch-application-repo-revision.yaml
-    target:
-      group: argoproj.io
-      kind: Application
+#Uncomment below patching for repo setup for each overlay
+#patches:
+# set the repo and branch for applications
+#- path: patch-application-repo-revision.yaml
+#  target:
+#    group: argoproj.io
+#    kind: Application
   # Uncomment patches to disable automatic sync
   # - path: patch-applicationset-manual-sync.yaml
   #   target:

--- a/clusters/overlays/rhoai-fast/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
   - ../../base
   - ../../../components/argocd/apps/overlays/rhoai-fast
 
-patches:
-  # set the repo and branch for applications
-  - path: patch-application-repo-revision.yaml
-    target:
-      group: argoproj.io
-      kind: Application
+#Uncomment below patching for repo setup for each overlay
+#patches:
+# set the repo and branch for applications
+#- path: patch-application-repo-revision.yaml
+#  target:
+#    group: argoproj.io
+#    kind: Application
   # Uncomment patches to disable automatic sync
   # - path: patch-applicationset-manual-sync.yaml
   #   target:

--- a/clusters/overlays/rhoai-stable-2.10/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.10/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
 - ../../base
 - ../../../components/argocd/apps/overlays/rhoai-stable-2.10
 
-patches:
+#Uncomment below patching for repo setup for each overlay
+#patches:
 # set the repo and branch for applications
-- path: patch-application-repo-revision.yaml
-  target:
-    group: argoproj.io
-    kind: Application
+#- path: patch-application-repo-revision.yaml
+#  target:
+#    group: argoproj.io
+#    kind: Application
 # Uncomment patches to disable automatic sync
 # - path: patch-applicationset-manual-sync.yaml
 #   target:

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,8 +12,8 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: patch-me-see-clusters-overlays
-    targetRevision: patch-me-see-clusters-overlays
+    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git  # Update me on fork
+    targetRevision: main
   syncPolicy:
     automated:
       prune: false

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/sukantadash/ai-accelerator.git # Update me on fork
+    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git  # Update me on fork
     targetRevision: main
   syncPolicy:
     automated:

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git  # Update me on fork
+    repoURL: https://github.com/sukantadash/ai-accelerator.git # Update me on fork
     targetRevision: main
   syncPolicy:
     automated:

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -49,12 +49,11 @@ Execute the bootstrap script to begin the installation process:
 ./scripts/bootstrap.sh
 ```
 
-By default, the script uses the repository `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch. The script will prompt you to input a different repository and revision if desired. If you choose to provide alternate values, the following will occur:
+By default, the script uses the repository `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch. The script will prompt for a different repository and branch if desired. If alternate values are provided, the following will occur:
 
-Temporary Change: The repository change is temporary and will not be committed to the Git repository.
-Out-of-Sync ArgoCD Application: The `cluster-config-app-of-apps` application in ArgoCD will show as out-of-sync. If you manually sync it, the repository will revert to the default `(https://github.com/redhat-ai-services/ai-accelerator.git)` repo.
-Testing with a Local Repository: You can update the default repository to a local repository to test code changes before committing.
-
+- The repository change is temporary and will not be committed to the Git repository.
+- The `cluster-config-app-of-apps` application in ArgoCD will show as out-of-sync. If manually synced, the repository will revert to the default `(https://github.com/redhat-ai-services/ai-accelerator.git)` repo.
+- The default repository can be updated to a local repository to test code changes or run the accelerator using a different repository.
 
 When prompted to select a bootstrap folder, choose the overlay that matches your cluster version, for example: `bootstrap/overlays/rhoai-eus-2.8/`.
 

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -48,12 +48,12 @@ Execute the bootstrap script to begin the installation process:
 ```sh
 ./scripts/bootstrap.sh
 ```
+The script defaults to using the central repository at `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch for GitOps configuration. If your working remote repository differs, the script will prompt you to update the GitOps configuration to match. Selecting this option will:
 
-By default, the script uses the repository `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch. The script will prompt for a different repository and branch if desired. If alternate values are provided, the following will occur:
+- Update the repository and branch in `cluster-config-app-of-apps`.
+- Commit the changes locally.
+- Require you to push the updated file `cluster-config-app-of-apps` to the central - repository `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch before submitting a pull request.
 
-- The repository change is temporary and will not be committed to the Git repository.
-- The `cluster-config-app-of-apps` application in ArgoCD will show as out-of-sync. If manually synced, the repository will revert to the default `(https://github.com/redhat-ai-services/ai-accelerator.git)` repo.
-- The default repository can be updated to a local repository to test code changes or run the accelerator using a different repository.
 
 When prompted to select a bootstrap folder, choose the overlay that matches your cluster version, for example: `bootstrap/overlays/rhoai-eus-2.8/`.
 

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -49,6 +49,13 @@ Execute the bootstrap script to begin the installation process:
 ./scripts/bootstrap.sh
 ```
 
+By default, the script uses the repository `(https://github.com/redhat-ai-services/ai-accelerator.git)` and the main branch. The script will prompt you to input a different repository and revision if desired. If you choose to provide alternate values, the following will occur:
+
+Temporary Change: The repository change is temporary and will not be committed to the Git repository.
+Out-of-Sync ArgoCD Application: The `cluster-config-app-of-apps` application in ArgoCD will show as out-of-sync. If you manually sync it, the repository will revert to the default `(https://github.com/redhat-ai-services/ai-accelerator.git)` repo.
+Testing with a Local Repository: You can update the default repository to a local repository to test code changes before committing.
+
+
 When prompted to select a bootstrap folder, choose the overlay that matches your cluster version, for example: `bootstrap/overlays/rhoai-eus-2.8/`.
 
 The `bootstrap.sh` script will now install the OpenShift GitOps Operator, create an ArgoCD instance once the operator is deployed in the `openshift-gitops` namespace, then bootstrap a set of ArgoCD applications to configure the cluster.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,53 +12,41 @@ GITOPS_OVERLAY=components/operators/openshift-gitops/operator/overlays/latest/
 
 YAML_FILE="./components/argocd/apps/base/cluster-config-app-of-apps.yaml"
 
-CURRENT_REPO_URL="https://github.com/redhat-ai-services/ai-accelerator.git"
-CURRENT_REPO_REVISION="main"
-NEW_REPO_URL=""
-NEW_REPO_REVISION=""
-
 
 confirm_repo_update(){
 
-CURRENT_REPO_URL=$(yq eval '.spec.source.repoURL' "$YAML_FILE")
-CURRENT_REPO_REVISION=$(yq eval '.spec.source.targetRevision' "$YAML_FILE")
+REPO_URL=$(yq eval '.spec.source.repoURL' "$YAML_FILE")
+REPO_REVISION=$(yq eval '.spec.source.targetRevision' "$YAML_FILE")
 
+# Get the current working repo URL (from the 'origin' remote)
+WORKING_REPO_URL=$(git remote get-url origin)
+# Get the current working repo branch
+WORKING_REPO_REVISION=$(git rev-parse --abbrev-ref HEAD) 
 
-# Prompt the user for a new Repo, defaulting to the old repo if no input is given
-read -p "Your environment will be provisioned through ArgoCD using the following Git repo, you can use default (press Enter) or change it:
-- Git Repository [$CURRENT_REPO_URL]: " NEW_REPO_URL
+if [[ "$REPO_URL" != "$WORKING_REPO_URL" ]] || [[ "$REPO_REVISION" != "$WORKING_REPO_REVISION" ]]; then
 
-read -p "- Git Repository Revision [$CURRENT_REPO_REVISION]: " NEW_REPO_REVISION
+  # Prompt the user for a new Repo, defaulting to the gitops configured repo if no input is given
+  read -p "Your GitOps process is currently configured to use the repository $REPO_URL on branch $REPO_REVISION, 
+  but your current working repository is $WORKING_REPO_URL on branch $WORKING_REPO_REVISION. 
+  Do you want to reconfigure the GitOps process to use the current working repository? (Y/N): N " USER_CHOICE
 
-echo "User entered rep: $NEW_REPO_URL Revision: $NEW_REPO_REVISION"
+  echo "You selected" $USER_CHOICE
+  # Use the old URL if no new URL is provided
+  if [[ -z "$USER_CHOICE" ]] || ([[ "$USER_CHOICE" != 'y' ]] && [[ "$USER_CHOICE" != 'Y' ]]); then
+      echo "No change in repository proceed with default option"
+  else
+      echo "updaing working repository"
+      yq eval ".spec.source.repoURL = \"$WORKING_REPO_URL\"" -i "$YAML_FILE"
+      yq eval ".spec.source.targetRevision = \"$WORKING_REPO_REVISION\"" -i "$YAML_FILE"
 
-# Use the old URL if no new URL is provided
-if [ -z "$NEW_REPO_URL" ]; then
-    NEW_REPO_URL=$CURRENT_REPO_URL
-    echo "No new Repo URL provided. Using the old URL: $CURRENT_REPO_URL"
-fi
-
-if [ -z "$NEW_REPO_REVISION" ]; then
-    NEW_REPO_REVISION=$CURRENT_REPO_REVISION
-    echo "No new Repo Revision provided. Using the old URL: $CURRENT_REPO_REVISION"
-fi
-
-if [[ "$CURRENT_REPO_URL" != "$NEW_REPO_URL" ]] || [[ "$CURRENT_REPO_REVISION" != "$NEW_REPO_REVISION" ]]; then
-  echo "updating rep: $NEW_REPO_URL Revision: $NEW_REPO_REVISION" in the file $YAML_FILE
-  # Use sed to replace the old variables with the new ones in the YAML file
-  cp $YAML_FILE $YAML_FILE.bak
-  yq eval ".spec.source.repoURL = \"$NEW_REPO_URL\"" -i $YAML_FILE
-  yq eval ".spec.source.targetRevision = \"$NEW_REPO_REVISION\"" -i $YAML_FILE
-  yq eval 'del(.spec.syncPolicy)' -i $YAML_FILE
-
-fi
-
-}
-
-cleanup_repo_changes(){
-  if [[ "$CURRENT_REPO_URL" != "$NEW_REPO_URL" ]] || [[ "$CURRENT_REPO_REVISION" != "$NEW_REPO_REVISION" ]]; then
-    mv $YAML_FILE.bak $YAML_FILE
+      git add "$YAML_FILE"
+      git commit -m "updated by bootstrap process" --  "$YAML_FILE"
+      git push origin "$WORKING_REPO_REVISION"
   fi
+else
+  echo "No mismatch in repository"
+fi
+
 }
 
 apply_firmly(){
@@ -159,4 +147,3 @@ check_oc_login
 confirm_repo_update
 install_gitops
 bootstrap_cluster
-cleanup_repo_changes

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,57 @@ OPERATOR_NS="openshift-gitops-operator"
 ARGO_NS="openshift-gitops"
 GITOPS_OVERLAY=components/operators/openshift-gitops/operator/overlays/latest/
 
+YAML_FILE="./components/argocd/apps/base/cluster-config-app-of-apps.yaml"
+
+CURRENT_REPO_URL="https://github.com/redhat-ai-services/ai-accelerator.git"
+CURRENT_REPO_REVISION="main"
+NEW_REPO_URL=""
+NEW_REPO_REVISION=""
+
+
+confirm_repo_update(){
+
+CURRENT_REPO_URL=$(yq eval '.spec.source.repoURL' "$YAML_FILE")
+CURRENT_REPO_REVISION=$(yq eval '.spec.source.targetRevision' "$YAML_FILE")
+
+
+# Prompt the user for a new Repo, defaulting to the old repo if no input is given
+read -p "Your environment will be provisioned through ArgoCD using the following Git repo, you can use default (press Enter) or change it:
+- Git Repository [$CURRENT_REPO_URL]: " NEW_REPO_URL
+
+read -p "- Git Repository Revision [$CURRENT_REPO_REVISION]: " NEW_REPO_REVISION
+
+echo "User entered rep: $NEW_REPO_URL Revision: $NEW_REPO_REVISION"
+
+# Use the old URL if no new URL is provided
+if [ -z "$NEW_REPO_URL" ]; then
+    NEW_REPO_URL=$CURRENT_REPO_URL
+    echo "No new Repo URL provided. Using the old URL: $CURRENT_REPO_URL"
+fi
+
+if [ -z "$NEW_REPO_REVISION" ]; then
+    NEW_REPO_REVISION=$CURRENT_REPO_REVISION
+    echo "No new Repo Revision provided. Using the old URL: $CURRENT_REPO_REVISION"
+fi
+
+if [[ "$CURRENT_REPO_URL" != "$NEW_REPO_URL" ]] || [[ "$CURRENT_REPO_REVISION" != "$NEW_REPO_REVISION" ]]; then
+  echo "updating rep: $NEW_REPO_URL Revision: $NEW_REPO_REVISION" in the file $YAML_FILE
+  # Use sed to replace the old variables with the new ones in the YAML file
+  cp $YAML_FILE $YAML_FILE.bak
+  yq eval ".spec.source.repoURL = \"$NEW_REPO_URL\"" -i $YAML_FILE
+  yq eval ".spec.source.targetRevision = \"$NEW_REPO_REVISION\"" -i $YAML_FILE
+  yq eval 'del(.spec.syncPolicy)' -i $YAML_FILE
+
+fi
+
+}
+
+cleanup_repo_changes(){
+  if [[ "$CURRENT_REPO_URL" != "$NEW_REPO_URL" ]] || [[ "$CURRENT_REPO_REVISION" != "$NEW_REPO_REVISION" ]]; then
+    mv $YAML_FILE.bak $YAML_FILE
+  fi
+}
+
 apply_firmly(){
   if [ ! -f "${1}/kustomization.yaml" ]; then
     echo "Please provide a dir with \"kustomization.yaml\""
@@ -105,5 +156,7 @@ check_oc_login
 #check_sealed_secret
 
 # Execute bootstrap functions
+confirm_repo_update
 install_gitops
 bootstrap_cluster
+cleanup_repo_changes


### PR DESCRIPTION
Please review the changes.

1. User will be given option to change the repository to the forked/local repo while running bootstrap script.
2. This change of repository is temporary change and doesn't commit to the git repo hence the ArgoCD application cluster-config-app-of-apps remains as out-of-sync in ArgoCD. Donot sync this application. if synced then the repository will be replaced with the redhat-ai-service/ai-accelerator.git
3. Everytime when the bootstrap script runs, it will be given option to change the repo to the forked/local repo
4. Now the repository change in one place that is in the file ./components/argocd/apps/base/cluster-config-app-of-apps.yaml
5. If user wants to use a different repository with respect respect to different overlay then they have to uncomment the patching code in the respective kustomization.yaml file 

e.g. /clusters/overlays/rhoai-stable-2.10/kustomization.yaml

```
#Uncomment below patching for repo setup for each overlay
#patches:
# set the repo and branch for applications
#- path: patch-application-repo-revision.yaml
#  target:
#    group: argoproj.io
#    kind: Application
```

