### PR TITLE
Skip gitops install if already installed

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -34,10 +34,10 @@ apply_firmly(){
 
 install_gitops(){
   echo
-  echo "Checking if GitOps Operator is already installed"
+  echo "Checking if GitOps Operator is already installed and running"
   if [[ $(oc get pod -n ${OPERATOR_NS} --no-headers -o custom-columns=":status.phase") == "Running" ]]; then
     echo
-    echo "GitOps operator is already installed."
+    echo "GitOps operator is already installed and running"
   else
     echo
     echo "Installing GitOps Operator."


### PR DESCRIPTION
Currently the bootstrap script tries to do a basic install of OpenShift GitOps and after the bootstrap it applies additional configurations.

If a user attempts to run the bootstrap script a second time it causes issues where the bootstrap script can't get past the "install gitops" step even though it is already installed.

This adds a simple check to see if the operator is already installed and allows the process to proceed to the rest of the bootstrap process.