### PR TITLE
increase max resources

### DIFF
--- a/components/cluster-configs/autoscaling/base/clusterautoscaler.yaml
+++ b/components/cluster-configs/autoscaling/base/clusterautoscaler.yaml
@@ -8,10 +8,10 @@ spec:
     maxNodesTotal: 7
     cores:
       min: 0
-      max: 64
+      max: 96
     memory:
       min: 0
-      max: 256
+      max: 384
     gpus:
       - type: nvidia.com/gpu
         min: 0


### PR DESCRIPTION
Increase the max number of resources available for an autoscaled cluster to allow for up to 6 nodes.