### PR TITLE
remove 2.13 patches

### DIFF
--- a/clusters/overlays/rhoai-stable-2.13-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.13-aws-gpu/kustomization.yaml
@@ -7,12 +7,8 @@ resources:
 - ../../base
 - ../../../components/argocd/apps/overlays/rhoai-stable-2.13-aws-gpu
 
-patches:
+# patches:
 # set the repo and branch for applications
-- path: patch-application-repo-revision.yaml
-  target:
-    group: argoproj.io
-    kind: Application
 # Uncomment patches to disable automatic sync
 # - path: patch-applicationset-manual-sync.yaml
 #   target:

--- a/clusters/overlays/rhoai-stable-2.13-aws-gpu/patch-application-repo-revision.yaml
+++ b/clusters/overlays/rhoai-stable-2.13-aws-gpu/patch-application-repo-revision.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/source/repoURL
-  value: 'https://github.com/redhat-ai-services/ai-accelerator.git'
-- op: replace
-  path: /spec/source/targetRevision
-  value: main

--- a/clusters/overlays/rhoai-stable-2.13/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.13/kustomization.yaml
@@ -7,12 +7,8 @@ resources:
 - ../../base
 - ../../../components/argocd/apps/overlays/rhoai-stable-2.13
 
-patches:
+# patches:
 # set the repo and branch for applications
-- path: patch-application-repo-revision.yaml
-  target:
-    group: argoproj.io
-    kind: Application
 # Uncomment patches to disable automatic sync
 # - path: patch-applicationset-manual-sync.yaml
 #   target:

--- a/clusters/overlays/rhoai-stable-2.13/patch-application-repo-revision.yaml
+++ b/clusters/overlays/rhoai-stable-2.13/patch-application-repo-revision.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/source/repoURL
-  value: 'https://github.com/redhat-ai-services/ai-accelerator.git'
-- op: replace
-  path: /spec/source/targetRevision
-  value: main


### PR DESCRIPTION
Remove the repo/revision patches in the 2.13 examples to align with the rest of the clusters.