### PR TITLE
update for self signed cert issues

### DIFF
--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git  # Update me on fork
+    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git # Update me on fork
     targetRevision: main
   syncPolicy:
     automated:

--- a/components/operators/openshift-ai/instance/components/components-serving-self-signed/README.md
+++ b/components/operators/openshift-ai/instance/components/components-serving-self-signed/README.md
@@ -1,0 +1,26 @@
+# components-serving-self-signed
+
+## Purpose
+This component is designed help configure the serving specific components including the following items:
+
+KServe
+ModelMesh
+
+This component enables KServe with a Self Signed certification that is compatible with versions prior to 2.13.
+
+For OpenShift AI 2.13 and new, it is recommended that you use the `components-serving` instead.
+
+## Usage
+
+This component can be added to a base by adding the `components` section to your overlay `kustomization.yaml` file:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/components-serving-self-signed
+```

--- a/components/operators/openshift-ai/instance/components/components-serving-self-signed/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/components/components-serving-self-signed/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-datasciencecluster.yaml
+    target:
+      kind: DataScienceCluster
+  - path: patch-dsc-init.yaml
+    target:
+      kind: DSCInitialization
+
+components:
+  - ../wait-for-servicemesh

--- a/components/operators/openshift-ai/instance/components/components-serving-self-signed/patch-datasciencecluster.yaml
+++ b/components/operators/openshift-ai/instance/components/components-serving-self-signed/patch-datasciencecluster.yaml
@@ -9,7 +9,7 @@ spec:
       serving:
         ingressGateway:
           certificate:
-            type: OpenshiftDefaultIngress
+            type: SelfSigned
         managementState: Managed
         name: knative-serving
     modelmeshserving:

--- a/components/operators/openshift-ai/instance/components/components-serving-self-signed/patch-dsc-init.yaml
+++ b/components/operators/openshift-ai/instance/components/components-serving-self-signed/patch-dsc-init.yaml
@@ -1,0 +1,11 @@
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  serviceMesh:
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed

--- a/components/operators/openshift-ai/instance/overlays/eus-2.8-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/eus-2.8-nvidia-gpu/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../base
 
 components:
-  - ../../components/components-serving
+  - ../../components/components-serving-self-signed
   - ../../components/components-training
   - ../../components/default-notebook-pvc-size
   - ../../components/idle-notebook-culling

--- a/components/operators/openshift-ai/instance/overlays/eus-2.8-serving-only/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/eus-2.8-serving-only/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - ../../base
 
 components:
-  - ../../components/components-serving
+  - ../../components/components-serving-self-signed
   - ../../components/model-server-pod-sizes
   - ../../components/rhoai-dashboard-access

--- a/components/operators/openshift-ai/instance/overlays/eus-2.8/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/eus-2.8/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../base
 
 components:
-  - ../../components/components-serving
+  - ../../components/components-serving-self-signed
   - ../../components/components-training
   - ../../components/default-notebook-pvc-size
   - ../../components/idle-notebook-culling

--- a/components/operators/openshift-ai/instance/overlays/stable-2.10/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.10/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../base
 
 components:
-  - ../../components/components-serving
+  - ../../components/components-serving-self-signed
   - ../../components/components-training
   - ../../components/default-notebook-pvc-size
   - ../../components/idle-notebook-culling

--- a/tenants/ai-example/single-model-serving-tgis/test/test-using-grpc.ipynb
+++ b/tenants/ai-example/single-model-serving-tgis/test/test-using-grpc.ipynb
@@ -82,10 +82,12 @@
     "\n",
     "from utils.tgis_grpc_client import TgisGrpcClient\n",
     "\n",
+    "# If using RHOAI 2.13 or new, set `verify=True`\n",
+    "# Older versions utilize a self-signed cert that is not trusted by default\n",
     "client = TgisGrpcClient(\n",
     "    hostname,\n",
     "    443,\n",
-    "    verify=False,\n",
+    "    verify=True,\n",
     ")\n",
     "\n",
     "client.make_request(\"At what temperature does Nitrogen boil?\", model_id=model_id)"

--- a/tenants/ai-example/single-model-serving-vllm/test/granite-test.ipynb
+++ b/tenants/ai-example/single-model-serving-vllm/test/granite-test.ipynb
@@ -105,7 +105,9 @@
     "        \"length_penalty\": 1\n",
     "    }\n",
     "\n",
-    "    response = requests.post(infer_url, json=json_data, verify=False)\n",
+    "    # If using RHOAI 2.13 or new, set `verify=True`\n",
+    "    # Older versions utilize a self-signed cert that is not trusted by default\n",
+    "    response = requests.post(infer_url, json=json_data, verify=True)\n",
     "    return response.json()"
    ]
   },


### PR DESCRIPTION
Update default RHOAI config to utilize cluster managed certs when possible.

The option to utilize cluster certs is available on 2.13 and version prior that should still utilize the self-signed certs option.