### PR TITLE
Fix for the NFD master node crash on OCP 4.17

### DIFF
--- a/components/operators/nfd/instance/base/node-feature-discovery.yaml
+++ b/components/operators/nfd/instance/base/node-feature-discovery.yaml
@@ -15,7 +15,11 @@ spec:
   operand:
     # bug: an image has to be defined otherwise the deployment fails
     # bug: this behavior recently changed
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:latest
+    #
+    # New issue: using the `latest` tag causes NFD master node crashes related to incompatibility
+    # For now, set this version to be the same as the cluster OCP version number
+    # https://docs.openshift.com/container-platform/4.17/hardware_enablement/psap-node-feature-discovery-operator.html#creating-nfd-cr-cli_psap-node-feature-discovery-operator
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:4.16
     servicePort: 12000
   workerConfig:
     configData: |


### PR DESCRIPTION
This is a temporary fix for the Node Feature Discovery operator crashing on OCP 4.17 cluster, when the `latest` tag is used in the images. Most likely caused by update incompatible with the cluster version.

We decided to default this to 4.16, as this is the latest EUS version of OpenShift, and can be updated once OCP 4.18 is widely available. If running on an OCP 4.17 cluster, this value can be manually updated, however due to the short support cycle for 4.17 we're not expecting this to be widely used.

Additional context on OCP versions and releases: https://access.redhat.com/support/policy/updates/openshift#dates