### PR TITLE
Increasing tenant backoff timeout to prevent sync failures due to missing CRDs

### DIFF
--- a/components/argocd/apps/base/tenants-applicationset.yaml
+++ b/components/argocd/apps/base/tenants-applicationset.yaml
@@ -31,7 +31,7 @@ spec:
         retry:
           limit: 5
           backoff:
-            duration: 5s
+            duration: 30s
             factor: 2
             maxDuration: 20m
       source:


### PR DESCRIPTION
Tenant applications in ArgoCD often transition to 'Sync Failed' state after default 5 min backoff timeout due to various missing CRD's.
These CRD's are created as part of RHOAI operator installation done via openshift-ai-operator application.
This pull request is to increase tenant applications backoff duration so ArgoCD will continue to try waiting for CRD's creation.
Logic is tested by deploying ai-accelerator on demo cluster.