### PR TITLE
Multi model example grpc test fix

### DIFF
--- a/tenants/ai-example/multi-model-serving/README.md
+++ b/tenants/ai-example/multi-model-serving/README.md
@@ -8,5 +8,11 @@ Minio will be created in the namespace, as well as the minio login secret and th
 
 NOTE: For the deployed model, the inference route is character limited. If the route does not come up, check to make sure the name/url is less than 63 characters for it to be created.
 
+## Testing
+
+When creating workbench to run tests - make sure to use 'Standard Data Science' 2024.2 image.
+
+Test notebook using REST connectivity requires infer_url value updated to use correct location from fraud-detection-model OpenShift route.
+
 ### References:
 https://github.com/red-hat-data-services/credit-fraud-detection-demo

--- a/tenants/ai-example/multi-model-serving/test/test-using-grpc.ipynb
+++ b/tenants/ai-example/multi-model-serving/test/test-using-grpc.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# These modules are already installed on Standard Data Science image",
+    "# These modules are already installed on Standard Data Science image\n",
     "# !pip install grpcio grpcio-tools"
    ]
   },

--- a/tenants/ai-example/multi-model-serving/test/test-using-grpc.ipynb
+++ b/tenants/ai-example/multi-model-serving/test/test-using-grpc.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install grpcio grpcio-tools"
+    "# These modules are already installed on Standard Data Science image",
+    "# !pip install grpcio grpcio-tools"
    ]
   },
   {


### PR DESCRIPTION
Added testing section to the Multi Model example README file specifying the workbench image to by used.

Commented out grpcio and gprcio-tools modules installation.
These modules are already installed in 'Standard Data Science' workbench image.
When left uncommented - it will produce the following errors which are confusing as test logic will work fine.
So to avoid confusion - I'm proposing to comment out this command.

Command output:

Requirement already satisfied: grpcio in /opt/app-root/lib/python3.9/site-packages (1.67.1)
Collecting grpcio-tools
  Downloading grpcio_tools-1.71.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.5/2.5 MB 39.1 MB/s eta 0:00:00 0:00:01
Requirement already satisfied: setuptools in /opt/app-root/lib/python3.9/site-packages (from grpcio-tools) (69.2.0)
Collecting grpcio
  Downloading grpcio-1.71.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.9/5.9 MB 202.7 MB/s eta 0:00:00
Collecting protobuf<6.0dev,>=5.26.1
  Downloading protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl (319 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 319.7/319.7 kB 272.4 MB/s eta 0:00:00
Installing collected packages: protobuf, grpcio, grpcio-tools
  Attempting uninstall: protobuf
    Found existing installation: protobuf 4.25.5
    Uninstalling protobuf-4.25.5:
      Successfully uninstalled protobuf-4.25.5
  Attempting uninstall: grpcio
    Found existing installation: grpcio 1.67.1
    Uninstalling grpcio-1.67.1:
      Successfully uninstalled grpcio-1.67.1
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
kfp 2.9.0 requires protobuf<5,>=4.21.1, but you have protobuf 5.29.3 which is incompatible.
kfp-pipeline-spec 0.4.0 requires protobuf<5,>=4.21.1, but you have protobuf 5.29.3 which is incompatible.
kfp-kubernetes 1.3.0 requires protobuf<5,>=4.21.1, but you have protobuf 5.29.3 which is incompatible.
Successfully installed grpcio-1.71.0 grpcio-tools-1.71.0 protobuf-5.29.3

[notice] A new release of pip available: 22.2.2 -> 25.0.1
[notice] To update, run: pip install --upgrade pip 