### PR TITLE
Updated OpenShift AI Health Check, added Ready state

### DIFF
--- a/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencecluster-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencecluster-health-check.yaml
@@ -14,7 +14,7 @@
           degraded = false
           for i, condition in pairs(obj.status.conditions) do
             if condition.reason ~= "Removed" then
-              if condition.type == "Available" and condition.status == "True" then
+              if (condition.type == "Available" or condition.type == "Ready") and condition.status == "True" then
                 available = true
               elseif condition.type == "Progressing" then
                 if condition.status == "True" then


### PR DESCRIPTION
Looks like RHOAI 2.19 has changed the state message from "Available" to "Ready". Added an "or" statement to allow for both older and newer versions.

More information in this issue: https://github.com/redhat-ai-services/ai-accelerator/issues/118

Tested working on an AWS cluster deployed using the `rhoai-fast-aws-gpu` overlay (currently deploying RHOAI 2.19), the health check is no longer showing degraded for an otherwise health cluster:

<img width="936" alt="image" src="https://github.com/user-attachments/assets/e967b838-a95e-404b-b8ae-963376f199ff" />


