### PR TITLE
Update pipelines

### DIFF
--- a/.wordlist-txt
+++ b/.wordlist-txt
@@ -25,7 +25,6 @@ CloudEvents
 ClusterRole
 ClusterRoleBinding
 ClusterRoleBindings
-ClusterTask
 CodeFlare
 CodeReady
 ConfigMap

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     path: patch-me-see-overlays
     repoURL: https://github.com/redhat-ai-services/ai-accelerator.git
-    targetRevision: main
+    targetRevision: update-pipelines
   syncPolicy:
     automated:
       prune: false

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git
+    repoURL: https://github.com/git@work-githumb-user:redhat-ai-services/ai-accelerator.git
     targetRevision: update-pipelines
   syncPolicy:
     automated:

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     path: patch-me-see-overlays
     repoURL: https://github.com/redhat-ai-services/ai-accelerator.git
-    targetRevision: update-pipelines
+    targetRevision: main
   syncPolicy:
     automated:
       prune: false

--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/git@work-githumb-user:redhat-ai-services/ai-accelerator.git
+    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git
     targetRevision: update-pipelines
   syncPolicy:
     automated:

--- a/documentation/training_and_learning/custom_workbench/pipeline.yaml
+++ b/documentation/training_and_learning/custom_workbench/pipeline.yaml
@@ -73,8 +73,14 @@ spec:
       runAfter:
         - git-clone
       taskRef:
-        kind: ClusterTask
-        name: buildah
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: buildah
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
       workspaces:
         - name: source
           workspace: output

--- a/documentation/training_and_learning/custom_workbench/pipeline.yaml
+++ b/documentation/training_and_learning/custom_workbench/pipeline.yaml
@@ -8,41 +8,45 @@ spec:
   tasks:
     - name: git-clone
       params:
-        - name: url
+        - name: URL
           value: "https://github.com/redhat-ai-services/ai-accelerator"
-        - name: revision
+        - name: REVISION
           value: ""
-        - name: refspec
+        - name: REFSPEC
           value: ""
-        - name: submodules
+        - name: SUBMODULES
           value: "true"
-        - name: depth
+        - name: DEPTH
           value: "1"
-        - name: sslVerify
+        - name: SSL_VERIFY
           value: "true"
-        - name: crtFileName
+        - name: CRT_FILENAME
           value: ca-bundle.crt
-        - name: subdirectory
+        - name: SUBDIRECTORY
           value: ""
-        - name: sparseCheckoutDirectories
+        - name: SPARSE_CHECKOUT_DIRECTORIES
           value: ""
-        - name: deleteExisting
+        - name: DELETE_EXISTING
           value: "true"
-        - name: httpProxy
+        - name: HTTP_PROXY
           value: ""
-        - name: httpsProxy
+        - name: HTTPS_PROXY
           value: ""
-        - name: noProxy
+        - name: NO_PROXY
           value: ""
-        - name: verbose
+        - name: VERBOSE
           value: "true"
-        - name: gitInitImage
-          value: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:66f219b4d54a41b945cb5715ecd1fbb5d25431cf8dad4b06914a4cdc65b298cc"
-        - name: userHome
+        - name: USER_HOME
           value: /home/git
       taskRef:
-        kind: ClusterTask
-        name: git-clone
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
       workspaces:
         - name: output
           workspace: output
@@ -50,15 +54,13 @@ spec:
       params:
         - name: IMAGE
           value: CHANGEME***/redhat-ods-applications/custom-wb
-        - name: BUILDER_IMAGE
-          value: "registry.redhat.io/rhel8/buildah@sha256:b48f410efa0ff8ab0db6ead420a5d8d866d64af846fece5efb185230d7ecf591"
         - name: STORAGE_DRIVER
           value: vfs
         - name: DOCKERFILE
           value: documentation/training_and_learning/custom_workbench/Dockerfile
         - name: CONTEXT
           value: .
-        - name: TLSVERIFY
+        - name: TLS_VERIFY
           value: "true"
         - name: FORMAT
           value: oci

--- a/tenants/ai-example/dsp-example-pipeline/base/dsp-example-pipeline.yaml
+++ b/tenants/ai-example/dsp-example-pipeline/base/dsp-example-pipeline.yaml
@@ -27,15 +27,19 @@ spec:
   tasks:
     - name: git-clone
       params:
-        - name: url
+        - name: URL
           value: $(params.GIT_URL)
-        - name: revision
+        - name: REVISION
           value: $(params.GIT_REVISION)
-        - name: gitInitImage
-          value: 'registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:868966ef9d4b54952d8a74eb83bba40eb1f52c0148994fa704efd0e3797c61c5'
       taskRef:
-        kind: ClusterTask
-        name: git-clone
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
       workspaces:
         - name: output
           workspace: source
@@ -43,15 +47,21 @@ spec:
       params:
         - name: VERSION
           value: $(params.PYTHON_IMAGE)
-        - name: PATH_CONTEXT
+        - name: CONTEXT
           value: .
         - name: IMAGE
           value: $(params.TARGET_IMAGE)
       runAfter:
         - git-clone
       taskRef:
-        kind: ClusterTask
-        name: s2i-python
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: s2i-python
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
       workspaces:
         - name: source
           workspace: source


### PR DESCRIPTION
**Overview:**

This pull request updates the pipelines within the AI Accelerator project to use the new `cluster scopped task` instead of the deprecated `ClusterTask`

**Testing:**

Ran both the changed pipelines. First was successful the second I manually added to the cluster and it ran and failed on buildah (but that is expected cause I did not make changes to the `CHANGEME` because I did not want to push an image). But the run should prove out that it was able to find and run the task.

Pipeline 1:

![image](https://github.com/user-attachments/assets/d7c3073a-ca53-404e-9143-940e4443ab40)

Pipeline 2:

![image](https://github.com/user-attachments/assets/e84310f6-3822-4def-a6ce-0006c04a682f)


Related Issues/Tickets

Closes **[#124](https://github.com/redhat-ai-services/ai-accelerator/issues/124)**

Additional Notes

Just as a note in a real prod environment I would always point my customers away from using Cluster Scoped task (instead capture the task in the customer's Git env and point to that). Because I have seen this cause issues to customer pipelines on cluster upgrades.

But not sure there is a good way to say "for demo purposes only" so going to let it go.
