### PR TITLE
disable depreciated modelmesh component

### DIFF
--- a/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
@@ -11,8 +11,8 @@ components:
   - ../../components/components-llamastack
   - ../../components/components-training
   - ../../components/components-trustyai
-  - ../../components/default-notebook-pvc-size
   - ../../components/dashboard-feature-hardware-profiles
+  - ../../components/default-notebook-pvc-size
   - ../../components/nvidia-gpu-hardware-profile
   - ../../components/idle-notebook-culling
   - ../../components/notebook-pod-sizes

--- a/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
   - ../../components/components-llamastack
-  - ../../components/components-modelmesh
   - ../../components/components-training
   - ../../components/components-trustyai
   - ../../components/default-notebook-pvc-size

--- a/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
@@ -10,8 +10,8 @@ components:
   - ../../components/components-kserve
   - ../../components/components-llamastack
   - ../../components/components-training
-  - ../../components/default-notebook-pvc-size
   - ../../components/dashboard-feature-hardware-profiles
+  - ../../components/default-notebook-pvc-size
   - ../../components/idle-notebook-culling
   - ../../components/notebook-pod-sizes
   - ../../components/make-kubeadmin-cluster-admin

--- a/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
   - ../../components/components-llamastack
-  - ../../components/components-modelmesh
   - ../../components/components-training
   - ../../components/default-notebook-pvc-size
   - ../../components/dashboard-feature-hardware-profiles


### PR DESCRIPTION
# What does this PR do?
This PR disables the modelmesh component by default for 2.22 similar to what we are already doing in the fast channel.

Modelmesh was depreciated in 2.19.

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
Render locally to validate results.

[//]: # (## Documentation)
