### PR TITLE
Add cli tooling checks and downloads

### DIFF
--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     path: patch-me-see-overlays
     repoURL: https://github.com/redhat-ai-services/ai-accelerator.git
-    targetRevision: main
+    targetRevision: add-cli-tooling-checks-and-downloads
   syncPolicy:
     automated:
       prune: false

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -94,7 +94,32 @@ download_kustomize(){
   cd ../..
 }
 
+download_yq(){
+  set +e
+  cli_path=${TMP_DIR}/bin/yq
+  DOWNLOAD_URL=https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+  echo "Downloading Yq CLI: ${DOWNLOAD_URL}" 
+  wget ${DOWNLOAD_URL} -O $cli_path
+  return_code=$?
 
+  # Check exit code of the last command
+  if [ $return_code -eq 0 ]; then
+    chmod +x $cli_path
+    return 0;
+  fi
+
+  while true; do
+    read -p "The download failed. Do you want to continue with the script? (y/n): " choice
+    case "$choice" in
+        [Yy]* ) echo "Continuing ..."; break;;          # continue script
+        [Nn]* ) echo "Exiting ..."; exit $return_code;;
+        * ) echo "Please answer y or n.";;
+    esac
+  done
+
+  set -e
+  return $return_code;
+}
 # check login
 check_oc_login(){
   oc cluster-info | head -n1


### PR DESCRIPTION
# What does this PR do?

Adds default download logic in the event yq is not already installed on the user's machine when bootstrapping. Also during download failure it prompts the user to halt or continue.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Checklist
- [ ] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [ ] Relevant documentation has been updated
- [ ] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan

Carried out the following use cases:
1. Installing yq on Linux  for first time. [DONE]
2. Download of yq on Linux fails. [DONE]
3. Yq already installed on Linux. [DONE]
4. Installing yq on Mac for first time. [TBD]
2. Download of yq on Mac fails. [TBD]
3. Yq already installed on Mac. [TBD]

[//]: # (## Documentation)
