### PR TITLE
Adding 3scale health checks to Gitops operator

### DIFF
--- a/components/operators/openshift-gitops/instance/components/README.md
+++ b/components/operators/openshift-gitops/instance/components/README.md
@@ -11,10 +11,9 @@ This repo currently contains the following components:
 * [gitops-admins](gitops-admins)
 * [health-check-odf](health-check-odf)
 * [health-check-olm](health-check-olm)
+* [health-check-3scale](health-check-3scale)
 * [health-check-openshift-builds](health-check-openshift-builds)
 * [kustomize-build-enable-helm](kustomize-build-enable-helm)
-
-## Usage
 
 ## Usage
 

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/kustomization.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-apimanager-health-check.yaml
+    target:
+      kind: ArgoCD
+  - path: patch-backend-health-check.yaml
+    target:
+      kind: ArgoCD
+  - path: patch-developeraccount-health-check.yaml
+    target:
+      kind: ArgoCD
+  - path: patch-developeruser-health-check.yaml
+    target:
+      kind: ArgoCD
+  - path: patch-product-health-check.yaml
+    target:
+      kind: ArgoCD

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-apimanager-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-apimanager-health-check.yaml
@@ -1,0 +1,46 @@
+- op: add
+  path: /spec/resourceHealthChecks/-
+  value:
+    group: apps.3scale.net
+    kind: APIManager
+    check: |
+      local health_status = {}
+
+      health_status.status = "Progressing"
+      health_status.message = "Waiting for APIManager to report status..."
+
+      if obj.status ~= nil then
+
+        local progressing = false
+        local degraded = false
+        local msg = ""
+
+        if obj.status.conditions ~= nil then
+          for i, condition in pairs(obj.status.conditions) do
+
+            if condition.status ~= "True" then
+              progressing = true
+              msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status
+              if condition.reason ~= nil and condition.reason ~= "" then
+                msg = msg .. " | " .. condition.reason
+              end
+              if condition.message ~= nil and condition.message ~= "" then
+                msg = msg .. " | " .. condition.message
+              end
+              msg = msg .. "\n"
+            end
+
+          end
+
+          if progressing == false then
+            health_status.status = "Progressing"
+          else
+            health_status.status = "Healthy"
+            msg = "InferenceService is healthy."
+          end
+
+          health_status.message = msg
+        end
+      end
+
+      return health_status

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-backend-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-backend-health-check.yaml
@@ -1,0 +1,31 @@
+- op: add
+  path: /spec/resourceHealthChecks/-
+  value:
+    group: capabilities.3scale.net
+    kind: Backend
+    check: |
+      local health_status = {}
+
+      if obj.status ~= nil then
+
+        if obj.status.conditions ~= nil then
+
+          for _, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Failed" and condition.status == "True" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            elseif condition.type == "Synced" and condition.status == "False" then
+              health_status.status = "Progressing"
+              health_status.message = "Waiting for 'Synced' status condition."
+              return health_status
+            end
+
+          end
+
+        end
+      end
+
+      health_status.status = "Healthy"
+      health_status.message = "Backend is ready to be used."
+      return health_status

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-developeraccount-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-developeraccount-health-check.yaml
@@ -1,0 +1,31 @@
+- op: add
+  path: /spec/resourceHealthChecks/-
+  value:
+    group: capabilities.3scale.net
+    kind: DeveloperAccount
+    check: |
+      local health_status = {}
+
+      if obj.status ~= nil then
+
+        if obj.status.conditions ~= nil then
+
+          for _, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Failed" and condition.status == "True" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            elseif condition.type == "Ready" and condition.status == "True" then
+              health_status.status = "Healthy"
+              health_status.message = "DeveloperAccount is ready to be used."
+              return health_status
+            end
+
+          end
+
+        end
+      end
+
+      health_status.status = "Progressing"
+      health_status.message = "DeveloperAccount is being prepared for use."
+      return health_status

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-developeruser-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-developeruser-health-check.yaml
@@ -1,0 +1,31 @@
+- op: add
+  path: /spec/resourceHealthChecks/-
+  value:
+    group: capabilities.3scale.net
+    kind: DeveloperUser
+    check: |
+      local health_status = {}
+
+      if obj.status ~= nil then
+
+        if obj.status.conditions ~= nil then
+
+          for _, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Failed" and condition.status == "True" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            elseif condition.type == "Ready" and condition.status == "True" then
+              health_status.status = "Healthy"
+              health_status.message = "DeveloperUser is ready to be used."
+              return health_status
+            end
+
+          end
+
+        end
+      end
+
+      health_status.status = "Progressing"
+      health_status.message = "DeveloperUser is being prepared for use."
+      return health_status

--- a/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-product-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-3scale/patch-product-health-check.yaml
@@ -1,0 +1,31 @@
+- op: add
+  path: /spec/resourceHealthChecks/-
+  value:
+    group: capabilities.3scale.net
+    kind: Product
+    check: |
+      local health_status = {}
+
+      if obj.status ~= nil then
+
+        if obj.status.conditions ~= nil then
+
+          for _, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Failed" and condition.status == "True" then
+              health_status.status = "Degraded"
+              health_status.message = condition.message
+              return health_status
+            elseif condition.type == "Synced" and condition.status == "False" then
+              health_status.status = "Progressing"
+              health_status.message = "Waiting for 'Synced' status condition."
+              return health_status
+            end
+
+          end
+
+        end
+      end
+
+      health_status.status = "Healthy"
+      health_status.message = "Product is ready to be used."
+      return health_status

--- a/components/operators/openshift-gitops/instance/overlays/rhdp/kustomization.yaml
+++ b/components/operators/openshift-gitops/instance/overlays/rhdp/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../components/edge-termination
   - ../../components/enable-notifications
   - ../../components/gitops-admins
+  - ../../components/health-check-3scale
   - ../../components/health-check-odf
   - ../../components/health-check-olm
   - ../../components/health-check-openshift-ai


### PR DESCRIPTION
# What does this PR do?
Add health checks on ArgoCD for 3scale CRs.

## Checklist
- [ ] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan

Deploy a 3scale instance on a cluster and check if `APIManager`s, `Backend`s, `DeveloperAccount`s, `DeveloperUser`s and `Product`s are showing health status.