### PR TITLE
Fix for degraded InferenceService with condition `Stopped` equals `False`

### DIFF
--- a/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-inferenceservice-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-inferenceservice-health-check.yaml
@@ -31,13 +31,19 @@
         if obj.status.conditions ~= nil then
           for i, condition in pairs(obj.status.conditions) do
 
+            if condition.type == "Stopped" and condition.status == "True" then
+              health_status.message = "InferenceService is stopped."
+              health_status.status = "Suspended"
+              return health_status
+            end
+
             if condition.status == "Unknown" then
               status_unknown = status_unknown + 1
-            elseif condition.status == "False" then
+            elseif condition.status == "False" and condition.type ~= "Stopped" then
               status_false = status_false + 1
             end
 
-            if condition.status ~= "True" then
+            if condition.status ~= "True" and condition.type ~= "Stopped" then
               msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status
               if condition.reason ~= nil and condition.reason ~= "" then
                 msg = msg .. " | " .. condition.reason


### PR DESCRIPTION
# What does this PR do?

This PR fixes wrong reporting of `InferenceService` instances that are reporting as degraded if a condition with type `Stopped` and status `False` is present.

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan

To verify the incorrect behavior, deploy the provided **kustomization** using ArgoCD and verify that the instance of `InferenceService` will be flagged as `Degraded`, even if it was deployed successfully.

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

helmCharts:
  - name: vllm-kserve
    releaseName: llama-32-1b-instruct-cpu
    version: 0.5.9
    repo: https://redhat-ai-services.github.io/helm-charts/
    valuesInline:
      fullnameOverride: llama-32-1b-instruct-cpu
      model:
        mode: uri
        uri: oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-1b-instruct
        args:
          - --max-model-len=2000
      deploymentMode: RawDeployment
      endpoint:
        externalRoute:
          enabled: false
      image:
        image: quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9
        tag: "0.3"
        runtimeVersionOverride: 0.7.3
```

Resulting InferenceService instance manifest (edited for brevity):

```yaml
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: llama-32-1b-instruct-cpu
spec:
  ## ...
status:
  address:
    url: http://llama-32-1b-instruct-cpu-predictor.llm-hosting.svc.cluster.local
  components:
    predictor: {}
  conditions:
  - lastTransitionTime: "2025-08-29T16:01:08Z"
    status: "True"
    type: IngressReady
  - lastTransitionTime: "2025-08-29T16:01:39Z"
    status: "True"
    type: PredictorReady
  - lastTransitionTime: "2025-08-29T16:01:39Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-08-29T16:01:08Z"
    severity: Info
    status: "False"
    type: Stopped
  deploymentMode: RawDeployment
  modelStatus:
    copies:
      failedCopies: 0
      totalCopies: 1
    states:
      activeModelState: Loaded
      targetModelState: Loaded
    transitionStatus: UpToDate
  observedGeneration: 1
  url: http://llama-32-1b-instruct-cpu-predictor.llm-hosting.svc.cluster.local
```

ArgoCD will show the `InferenceService` as `Degraded`:

<img width="699" height="366" alt="image" src="https://github.com/user-attachments/assets/66a91eb7-c553-414f-8279-f00b06720e16" />

But the model deployment is working:

```shell
$ oc debug -n llm-hosting
Starting pod/image-debug-xrc4c ...
Pod IP: 10.130.0.191
If you don't see a command prompt, try pressing enter.
sh-5.1# curl -X POST \
>     'http://llama-32-1b-instruct-cpu-predictor.llm-hosting.svc.cluster.local:8080/v1/completions' \
>     -H 'accept: application/json' \
>     -H 'Content-Type: application/json' \
>     -d '{
     "model": "llama-32-1b-instruct-cpu",
     "prompt": "Is this thing on?" 
 }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   483  100   405  100    78     26      5  0:00:15  0:00:15 --:--:--    98
{
  "id": "cmpl-7d7b4a1804b04a65abdf623ae74ea256",
  "object": "text_completion",
  "created": 1756488998,
  "model": "llama-32-1b-instruct-cpu",
  "choices": [
    {
      "index": 0,
      "text": " If not, how do i do it?\nDevices, such as smart home devices",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null
    }
  ],
  "usage": {
    "prompt_tokens": 6,
    "total_tokens": 22,
    "completion_tokens": 16,
    "prompt_tokens_details": null
  }
}
sh-5.1#
```
