### PR TITLE
fix: update custom argo health check for DataScienceCluster

### DIFF
--- a/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencecluster-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencecluster-health-check.yaml
@@ -19,16 +19,18 @@
               elseif condition.type == "Progressing" then
                 if condition.status == "True" then
                   progressing = true
-                  msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. condition.reason .. " | " .. condition.message .. "\n"
+                  msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. (condition.reason or "") .. " | " .. condition.message .. "\n"
                 end
               elseif condition.type == "Degraded" then
                 if condition.status == "True" then
                   degraded = true
-                  msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. condition.reason .. " | " .. condition.message .. "\n"
+                  msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. (condition.reason or "") .. " | " .. condition.message .. "\n"
                 end
               elseif condition.status == "False" then
-                componentsDegraded = componentsDegraded + 1
-                msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. condition.reason .. " | " .. condition.message .. "\n"
+                if condition.reason ~= nil and condition.reason ~= "Removed" then
+                  componentsDegraded = componentsDegraded + 1
+                end
+                msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. (condition.reason or "") .. " | " .. condition.message .. "\n"
               end
             end
 


### PR DESCRIPTION
Update argocd resource health check for DataScienceCluster CR to support if component object is empty.
- on status False, only count component as degraded if a reason is given
- prevent argo health check from failing if no reason is attached by adding reason field to msg only if it exists

# What does this PR do?
This PR updates the custom argocd healthcheck for the DataScienceCluster to not case in case there is no reason field provided within the status of a component.

Error before:
<img width="1199" height="664" alt="Bildschirmfoto 2025-09-05 um 12 24 50" src="https://github.com/user-attachments/assets/45bcbd0b-b359-4d0a-b12c-5bbd028f2517" />





## Checklist
- [ ] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [ ] Relevant documentation has been updated
- [ ] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
